### PR TITLE
[Vendors] Refactor to a better integration of client of gear

### DIFF
--- a/gear/http/HttpClient.cpp
+++ b/gear/http/HttpClient.cpp
@@ -1,3 +1,5 @@
+#include <asio.hpp>
+#include <asio/ssl.hpp>
 #include <iostream>
 #include <thread>
 
@@ -7,44 +9,34 @@
 namespace gear {
 class HttpClient::impl {
  public:
-  impl(asio::io_context& ioContext, asio::ssl::context& context,
-       const HttpRequest request, completion_handler handler)
-      : _socket(ioContext, context),
-        _resolver(ioContext),
-        _request(request),
-        _handler(handler) {
+  impl(asio::io_context& ioContext, asio::ssl::context& context, const HttpRequest request, completion_handler handler)
+      : _socket(ioContext, context), _resolver(ioContext), _request(request), _handler(handler) {
     _socket.set_verify_mode(asio::ssl::verify_peer);
     // TODO: When use this in production, we need to verify our host ...
     // #ifdef DEBUG
-    _socket.set_verify_callback(
-        [](bool, asio::ssl::verify_context&) { return true; });
+    _socket.set_verify_callback([](bool, asio::ssl::verify_context&) { return true; });
     // #else
     // _socket.set_verify_callback(
     // [](bool verified, asio::ssl::verify_context&) { return verified; });
     // #endif
 
-    _resolver.async_resolve(
-        _request.host(), "443",
-        bind(&impl::handleResolve, this, std::placeholders::_1, std::placeholders::_2));
+    _resolver.async_resolve(_request.host(), "443",
+                            bind(&impl::handleResolve, this, std::placeholders::_1, std::placeholders::_2));
   }
 
-  HttpRequest getRequest() const{ return _request; }
+  HttpRequest getRequest() const { return _request; }
 
   friend class HttpClient;
 
  private:
-  static std::unique_ptr<impl> execute(asio::io_context& ioContext,
-                                  asio::ssl::context& context,
-                                  const HttpRequest& request,
-                                  const completion_handler& handler) {
+  static std::unique_ptr<impl> execute(asio::io_context& ioContext, asio::ssl::context& context,
+                                       const HttpRequest& request, const completion_handler& handler) {
     return std::make_unique<impl>(ioContext, context, request, handler);
   }
 
-  void handleResolve(const std::error_code& error,
-                      asio::ip::tcp::resolver::results_type endpoints) {
+  void handleResolve(const std::error_code& error, asio::ip::tcp::resolver::results_type endpoints) {
     if (!error) {
-      asio::async_connect(_socket.lowest_layer(), endpoints,
-                          bind(&impl::handleConnect, this, std::placeholders::_1));
+      asio::async_connect(_socket.lowest_layer(), endpoints, bind(&impl::handleConnect, this, std::placeholders::_1));
     } else {
       handleError(error);
     }
@@ -52,9 +44,8 @@ class HttpClient::impl {
 
   void handleConnect(const std::error_code& error) {
     if (!error) {
-      _socket.async_handshake(
-          asio::ssl::stream_base::client,
-          bind(&impl::handleHandshake, this, std::placeholders::_1));
+      _socket.async_handshake(asio::ssl::stream_base::client,
+                              bind(&impl::handleHandshake, this, std::placeholders::_1));
     } else {
       handleError(error);
     }
@@ -63,9 +54,8 @@ class HttpClient::impl {
   void handleHandshake(const std::error_code& error) {
     if (!error) {
       auto request = writeRequest();
-      asio::async_write(
-          _socket, asio::buffer(request),
-          bind(&impl::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
+      asio::async_write(_socket, asio::buffer(request),
+                        bind(&impl::handleWrite, this, std::placeholders::_1, std::placeholders::_2));
     } else {
       handleError(error);
     }
@@ -74,15 +64,13 @@ class HttpClient::impl {
   void handleWrite(const std::error_code& error, size_t /*bytes_transferred*/) {
     if (!error) {
       asio::async_read_until(_socket, _streamResponse, "\r\n",
-                             bind(&impl::handleReadCodeAndMessage, this,
-                                  std::placeholders::_1, std::placeholders::_2));
+                             bind(&impl::handleReadCodeAndMessage, this, std::placeholders::_1, std::placeholders::_2));
     } else {
       handleError(error);
     }
   }
 
-  void handleReadCodeAndMessage(const std::error_code& error,
-                                    size_t /*bytes_transferred*/) {
+  void handleReadCodeAndMessage(const std::error_code& error, size_t /*bytes_transferred*/) {
     if (!error) {
       std::istream responseStream(&_streamResponse);
       std::string httpVersion;
@@ -93,21 +81,18 @@ class HttpClient::impl {
       getline(responseStream, statusMessage);
       _response.code(statusCode).message(statusMessage);
       asio::async_read_until(_socket, _streamResponse, "\r\n\r\n",
-                             bind(&impl::handleReadHeaders, this,
-                                  std::placeholders::_1, std::placeholders::_2));
+                             bind(&impl::handleReadHeaders, this, std::placeholders::_1, std::placeholders::_2));
     } else {
       handleError(error);
     }
   }
 
-  void handleReadHeaders(const std::error_code& error,
-                           size_t /*bytes_transferred*/) {
+  void handleReadHeaders(const std::error_code& error, size_t /*bytes_transferred*/) {
     if (!error) {
       // Process the response headers.
       std::istream responseStream(&_streamResponse);
       std::string headerString;
-      while (std::getline(responseStream, headerString) &&
-             headerString != "\r") {
+      while (std::getline(responseStream, headerString) && headerString != "\r") {
         auto header = gear_utils::split(headerString, ':');
         auto headerKey = header[0];
         auto headerValue = gear_utils::trim(header[0]);
@@ -124,12 +109,10 @@ class HttpClient::impl {
 
   void handleReadBody() {
     asio::async_read(_socket, _streamResponse, asio::transfer_at_least(1),
-                     bind(&impl::recursiveReadBody, this, std::placeholders::_1,
-                          std::placeholders::_2));
+                     bind(&impl::recursiveReadBody, this, std::placeholders::_1, std::placeholders::_2));
   }
 
-  void recursiveReadBody(const std::error_code& error,
-                           size_t /*bytes_transferred*/) {
+  void recursiveReadBody(const std::error_code& error, size_t /*bytes_transferred*/) {
     if (!error) {
       _responseStream << &_streamResponse;
       handleReadBody();
@@ -169,13 +152,11 @@ class HttpClient::impl {
     std::string body = _request.body();
     std::ostringstream os;
     os << verb << " " << _request.path();
-    if (_request.method() == HttpMethod::GET ||
-        _request.method() == HttpMethod::DELETE) {
+    if (_request.method() == HttpMethod::GET || _request.method() == HttpMethod::DELETE) {
       setQueriesToStream(os);
     }
     os << " HTTP/1.1\r\n";
-    if ((_request.method() == HttpMethod::POST ||
-         _request.method() == HttpMethod::PUT ||
+    if ((_request.method() == HttpMethod::POST || _request.method() == HttpMethod::PUT ||
          _request.method() == HttpMethod::PATCH) &&
         _request.body().size() > 0) {
       _request.addHeader("Content-Length", std::to_string(body.length()));
@@ -205,8 +186,7 @@ class HttpClient::impl {
         } else {
           os << "&";
         }
-        os << gear_utils::encodeUrl(query.first) + "=" +
-                  gear_utils::encodeUrl(query.second);
+        os << gear_utils::encodeUrl(query.first) + "=" + gear_utils::encodeUrl(query.second);
       }
     }
   }
@@ -221,18 +201,20 @@ class HttpClient::impl {
   completion_handler _handler;
 };
 
-HttpClient::HttpClient() : _sslContext(asio::ssl::context::sslv23) {
-  _sslContext.set_default_verify_paths();
+HttpClient::HttpClient()
+    : _ioContext(std::make_unique<asio::io_context>()),
+      _sslContext(std::make_unique<asio::ssl::context>(asio::ssl::context::sslv23)) {
+  _sslContext->set_default_verify_paths();
 }
 
 HttpClient::HttpClient(const std::string& uri) : HttpClient() {
   _config.host(uri);
-  setConfigToRequest();
+  applyConfig();
 }
 
 HttpClient::HttpClient(HttpConfig config) : HttpClient() {
   _config = config;
-  setConfigToRequest();
+  applyConfig();
 }
 
 HttpClient::~HttpClient() {
@@ -240,12 +222,11 @@ HttpClient::~HttpClient() {
 }
 
 void HttpClient::run() {
-  _ioContext.reset();
-  _ioContext.run();
+  _ioContext->reset();
+  _ioContext->run();
 }
 
-void HttpClient::execute(const HttpRequest& requestExecute,
-                          const completion_handler& handler) {
+void HttpClient::execute(const HttpRequest& requestExecute, const completion_handler& handler) {
   _request = requestExecute;
   if (_request.host().empty()) {
     _request.host(_config.host());
@@ -265,10 +246,10 @@ void HttpClient::execute(const HttpRequest& requestExecute,
 
 void HttpClient::execute(const completion_handler& handler) {
   reset();
-  _pimpl = impl::execute(_ioContext, _sslContext, _request, handler);
+  _pimpl = impl::execute(*_ioContext, *_sslContext, _request, handler);
   _thread = std::make_unique<std::thread>(&HttpClient::run, this);
   _request = gear::HttpRequest();
-  setConfigToRequest();
+  applyConfig();
 }
 
 void HttpClient::reset() {
@@ -277,11 +258,8 @@ void HttpClient::reset() {
   }
 }
 
-void HttpClient::setConfigToRequest() {
-  _request.host(_config.host())
-      .path(_config.basePath())
-      .headers(_config.baseHeaders())
-      .queries(_config.baseQueries());
+void HttpClient::applyConfig() {
+  _request.host(_config.host()).path(_config.basePath()).headers(_config.baseHeaders()).queries(_config.baseQueries());
 }
 
 void HttpClient::httpGet(const completion_handler& handler) {
@@ -336,12 +314,9 @@ HttpClient& HttpClient::method(const HttpMethod& method) {
   return *this;
 }
 
-std::unordered_map<std::string, std::string> HttpClient::headers() const {
-  return _request.headers();
-}
+std::unordered_map<std::string, std::string> HttpClient::headers() const { return _request.headers(); }
 
-HttpClient& HttpClient::headers(
-    const std::unordered_map<std::string, std::string>& headers) {
+HttpClient& HttpClient::headers(const std::unordered_map<std::string, std::string>& headers) {
   _request.headers(headers);
   return *this;
 }
@@ -358,9 +333,7 @@ HttpClient& HttpClient::body(const std::string& body) {
   return *this;
 }
 
-std::vector<std::pair<std::string, std::string>> HttpClient::queries() const {
-  return _request.queries();
-}
+std::vector<std::pair<std::string, std::string>> HttpClient::queries() const { return _request.queries(); }
 HttpClient& HttpClient::queries(const std::vector<std::pair<std::string, std::string>>& queries) {
   _request.queries(queries);
   return *this;

--- a/gear/http/HttpClient.hpp
+++ b/gear/http/HttpClient.hpp
@@ -1,14 +1,19 @@
-#include <asio.hpp>
-#include <asio/ssl.hpp>
 #include <experimental/optional>
 #include <thread>
 
+#include "HttpConfig.hpp"
 #include "HttpRequest.hpp"
 #include "HttpResponse.hpp"
-#include "HttpConfig.hpp"
 
-using completion_handler =
-    std::function<void(const gear::HttpRequest, const gear::HttpResponse)>;
+using completion_handler = std::function<void(const gear::HttpRequest, const gear::HttpResponse)>;
+
+namespace asio {
+class io_context;
+
+namespace ssl {
+class context;
+}
+}
 
 namespace gear {
 
@@ -44,18 +49,17 @@ class HttpClient final {
   void httpPost(const completion_handler& handler);
   void httpDelete(const completion_handler& handler);
   void httpPatch(const completion_handler& handler);
-  void execute(const HttpRequest& requestExecute,
-               const completion_handler& handler);
+  void execute(const HttpRequest& requestExecute, const completion_handler& handler);
   void execute(const completion_handler& handler);
 
  private:
   HttpClient();
   void reset();
   void run();
-  void setConfigToRequest();
+  void applyConfig();
 
-  asio::io_context _ioContext;
-  asio::ssl::context _sslContext;
+  std::unique_ptr<asio::io_context> _ioContext;
+  std::unique_ptr<asio::ssl::context> _sslContext;
   HttpRequest _request;
   HttpConfig _config;
   class impl;


### PR DESCRIPTION
- We need to remove `include_dir` out of the client of gear. So that, direct include in `.hpp` is not gonna work as it requires user to include `asio` in their project which doesn't make sense.

This PR serves just that.
